### PR TITLE
Update Window Painter runtime to 46

### DIFF
--- a/dev.jamiethalacker.window_painter.json
+++ b/dev.jamiethalacker.window_painter.json
@@ -1,7 +1,7 @@
 {
     "app-id": "dev.jamiethalacker.window_painter",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "windowpainter",
     "finish-args": [

--- a/dev.jamiethalacker.window_painter.json
+++ b/dev.jamiethalacker.window_painter.json
@@ -40,6 +40,10 @@
                         "url-query": ".tarball_url",
                         "timestamp-query": ".published_at"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
              ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,67 @@
+From 443ed289defe4fe56a988e4876710df1a232a4eb Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 9 Jun 2024 01:05:54 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/dev.jamiethalacker.window_painter.appdata.xml.in | 23 ++++-------------------
+ data/dev.jamiethalacker.window_painter.desktop.in     |  2 +-
+ 2 files changed, 5 insertions(+), 20 deletions(-)
+
+diff --git a/data/dev.jamiethalacker.window_painter.appdata.xml.in b/data/dev.jamiethalacker.window_painter.appdata.xml.in
+index b10ad5d..440c2a3 100644
+--- a/data/dev.jamiethalacker.window_painter.appdata.xml.in
++++ b/data/dev.jamiethalacker.window_painter.appdata.xml.in
+@@ -10,6 +10,9 @@
+ 	</description>
+   <url type="homepage">https://itsjamie.dev</url>
+   <url type="bugtracker">https://github.com/ItsJamie9494/window-painter/issues</url>
++  <url type="vcs-browser">https://github.com/ItsJamie9494/window-painter</url>
++  <url type="translate">https://github.com/ItsJamie9494/window-painter/tree/main/po</url>
++  <launchable type="desktop-id">dev.jamiethalacker.window_painter.desktop</launchable>
+   <developer_name>Jamie Murphy</developer_name>
+   <screenshots>
+     <screenshot type="default">
+@@ -47,26 +50,8 @@
+     <category>Game</category>
+     <category>ArcadeGame</category>
+   </categories>
+-  <content_rating type="oars-1.0">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
++  <content_rating type="oars-1.1">
+     <content_attribute id="social-chat">moderate</content_attribute>
+     <content_attribute id="social-info">mild</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+   </content_rating>
+ </component>
+diff --git a/data/dev.jamiethalacker.window_painter.desktop.in b/data/dev.jamiethalacker.window_painter.desktop.in
+index 9c5b841..d623e21 100644
+--- a/data/dev.jamiethalacker.window_painter.desktop.in
++++ b/data/dev.jamiethalacker.window_painter.desktop.in
+@@ -4,5 +4,5 @@ Exec=windowpainter
+ Icon=dev.jamiethalacker.window_painter
+ Terminal=false
+ Type=Application
+-Categories=GTK;
++Categories=GTK;Game;ArcadeGame;
+ StartupNotify=true
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update Window Painter runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts.